### PR TITLE
Add loadFromString and PSSR/SHA1 verifier

### DIFF
--- a/include/lcpubkey.h
+++ b/include/lcpubkey.h
@@ -13,6 +13,8 @@ public:
     virtual bool isValid() const = 0;
     virtual bool save(const std::string& filename) const = 0;
     virtual bool load(const std::string& filename) = 0;
+    virtual bool loadFromString(const std::string& content) = 0;
+    
     // auto_ptr is deprecated with C++11
     #if __cplusplus <= 199711L
         template<typename T> struct Pointer { typedef std::auto_ptr<T> Type; };
@@ -42,6 +44,9 @@ public:
 
     /// Load a public key from file.
     bool load(const std::string& filename);
+    
+    /// Load a public key from string
+    bool loadFromString(const std::string& content);
 
     /// Derive and set the public key from a private key.
     bool assignFrom(const PrivateKey& privateKey);
@@ -60,6 +65,10 @@ public:
     /// and recovered message part to dataOut.
     bool verifyWithRecovery(std::istream& dataIn, std::ostream& dataOut) const;
 
+    /// Verifies the input data with PSSR SHA1 signature and write out the message
+    /// and recovered message part to dataOut.
+    bool verifyWithPSSR_SHA1(std::istream& dataIn, std::ostream& dataOut) const;
+    
     /// Verifies the input data with recovery signature.
     bool verifyWithRecovery(std::istream& dataIn) const;
 
@@ -107,6 +116,9 @@ public:
 
     /// Load a public key from file.
     bool load(const std::string& filename);
+    
+    /// Load a private key from string
+    bool loadFromString(const std::string& content);
 
     /// Create and initialize new random private key with the given key size.
     bool create(unsigned int keySizeBit = 2048);

--- a/src/lcpubkey.cpp
+++ b/src/lcpubkey.cpp
@@ -25,6 +25,9 @@ namespace {
     typedef CryptoPP::RSASS<CryptoPP::PSSR, LcRSAHashFunction>::Signer RSA_Recovery_Signer;
     typedef CryptoPP::RSASS<CryptoPP::PSSR, LcRSAHashFunction>::Verifier RSA_Recovery_Verifier;
 
+    typedef CryptoPP::RSASS<CryptoPP::PSSR, CryptoPP::SHA1>::Verifier RSA_PSSR_SHA1_Verifier;
+    typedef CryptoPP::RSASS<CryptoPP::PSSR, CryptoPP::SHA1>::Signer RSA_PSSR_SHA1_Signer;
+    
     // Basic key functionality for public and private keys
     template <typename T>
     struct CCKeyImpl
@@ -73,7 +76,6 @@ namespace {
         }
 
         // Source can be either CryptoPP::FileSource or CryptoPP::StringSource
-        // Later implementations will also load and save keys from and to std::strings.
         template <typename Source>
         bool loadKeyBase64(const std::string& in)
         {
@@ -410,6 +412,11 @@ bool PrivateKey::load(const std::string &filename)
     return _impl->loadKeyBase64<CryptoPP::FileSource>(filename);
 }
 
+bool PrivateKey::loadFromString(const std::string &content)
+{
+    return _impl->loadKeyBase64<CryptoPP::StringSource>(content);
+}
+    
 bool PrivateKey::create(unsigned int keySizeBit)
 {
     _impl->reset();
@@ -517,6 +524,11 @@ bool PublicKey::load(const std::string& filename)
 {
     return _impl->loadKeyBase64<CryptoPP::FileSource>(filename);
 }
+    
+bool PublicKey::loadFromString(const std::string &content)
+{
+    return _impl->loadKeyBase64<CryptoPP::StringSource>(content);
+}
 
 bool PublicKey::assignFrom(const PrivateKey& privateKey)
 {
@@ -538,6 +550,11 @@ bool PublicKey::verifyWithAppendix(std::istream& dataIn, const std::string& sign
     return _impl->verify<RSA_Appendix_Verifier, AppendixVerifyFilter>(dataWithSignature);
 }
 
+bool PublicKey::verifyWithPSSR_SHA1(std::istream& dataIn, std::ostream& dataOut) const
+{
+    return _impl->verify<RSA_PSSR_SHA1_Verifier, AppendixVerifyFilter>(dataIn, dataOut);
+}
+    
 bool PublicKey::verifyWithAppendix(std::istream& dataIn, std::ostream& dataOut) const
 {
     return _impl->verify<RSA_Appendix_Verifier, AppendixVerifyFilter>(dataIn, dataOut);


### PR DESCRIPTION
loadFromString has practical reasons (you have yourself commented that future version will include this). I have also tested it within some of my private projects and it seems to work. Likewise, the interface is extended, so that it works for private and public keys alike.

This commit (yeah, it should probably be two commits) also introduces an additional verifier (and signer TYPE without sign function so far, though) because I need it for my existing signed files that I wanted to check against. I just titled it PSSR/SHA1 because that's what it is. If you have a trivial name for it, even better :)

Maybe, you would like to integrate it, maybe not. I tried to mirror your code style and commit message style.